### PR TITLE
#29  Request.Form raises error when content is not a form

### DIFF
--- a/src/KendoGridBinder.AspNetCore/ModelBinder/Mvc/KendoGridMvcModelBinder.cs
+++ b/src/KendoGridBinder.AspNetCore/ModelBinder/Mvc/KendoGridMvcModelBinder.cs
@@ -1,56 +1,56 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.Threading.Tasks;
-using System.Linq;
-using JetBrains.Annotations;
+﻿using JetBrains.Annotations;
+using KendoGridBinder.Extensions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Primitives;
-using KendoGridBinder.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Threading.Tasks;
 
 // ReSharper disable once CheckNamespace
 namespace KendoGridBinder.ModelBinder.Mvc
 {
-    public class KendoGridMvcModelBinder : IModelBinder
+  public class KendoGridMvcModelBinder : IModelBinder
+  {
+    public Task BindModelAsync([NotNull] ModelBindingContext bindingContext)
     {
-        public Task BindModelAsync([NotNull] ModelBindingContext bindingContext)
-        {
-            if (bindingContext == null)
-            {
-                throw new ArgumentNullException(nameof(bindingContext));
-            }
+      if (bindingContext == null)
+      {
+        throw new ArgumentNullException(nameof(bindingContext));
+      }
 
-            bool isForm = bindingContext.HttpContext.Request.HasFormContentType &&
-                          bindingContext.HttpContext.Request.Method.ToUpper() == "POST";
+      bool isForm = bindingContext.HttpContext.Request.HasFormContentType &&
+                    bindingContext.HttpContext.Request.Method.ToUpper() == "POST";
 
-            IEnumerable<KeyValuePair<string, StringValues>> form = bindingContext.HttpContext.Request.Form;
-            IEnumerable<KeyValuePair<string, StringValues>> query = bindingContext.HttpContext.Request.Query;
-            IEnumerable<KeyValuePair<string, StringValues>> collection = isForm ? form : query;
+      var collection = isForm ?
+       bindingContext.HttpContext.Request.Form as IEnumerable<KeyValuePair<string, StringValues>> :
+       bindingContext.HttpContext.Request.Query as IEnumerable<KeyValuePair<string, StringValues>>;
 
-            var queryString = new NameValueCollection();
-            foreach (KeyValuePair<string, StringValues> entry in collection)
-            {
-                string key = entry.Key;
-                string value = entry.Value.ToArray().FirstOrDefault();
-                queryString.Add(key, value);
-            }
+      var queryString = new NameValueCollection();
+      foreach (KeyValuePair<string, StringValues> entry in collection)
+      {
+        string key = entry.Key;
+        string value = entry.Value.ToArray().FirstOrDefault();
+        queryString.Add(key, value);
+      }
 
-            var kendoGridRequest = new KendoGridMvcRequest
-            {
-                Take = queryString.GetQueryValue("take", (int?)null),
-                Page = queryString.GetQueryValue("page", (int?)null),
-                Skip = queryString.GetQueryValue("skip", (int?)null),
-                PageSize = queryString.GetQueryValue("pageSize", (int?)null),
+      var kendoGridRequest = new KendoGridMvcRequest
+      {
+        Take = queryString.GetQueryValue("take", (int?)null),
+        Page = queryString.GetQueryValue("page", (int?)null),
+        Skip = queryString.GetQueryValue("skip", (int?)null),
+        PageSize = queryString.GetQueryValue("pageSize", (int?)null),
 
-                FilterObjectWrapper = FilterHelper.Parse(queryString),
-                GroupObjects = GroupHelper.Parse(queryString),
-                AggregateObjects = AggregateHelper.Parse(queryString),
-                SortObjects = SortHelper.Parse(queryString),
-            };
+        FilterObjectWrapper = FilterHelper.Parse(queryString),
+        GroupObjects = GroupHelper.Parse(queryString),
+        AggregateObjects = AggregateHelper.Parse(queryString),
+        SortObjects = SortHelper.Parse(queryString),
+      };
 
-            bindingContext.Result = ModelBindingResult.Success(kendoGridRequest);
+      bindingContext.Result = ModelBindingResult.Success(kendoGridRequest);
 
-            return Task.CompletedTask;
-        }
+      return Task.CompletedTask;
     }
+  }
 }


### PR DESCRIPTION
Hey @StefH your preview versions works great. But I spotted another issue, which I already had fixed a year ago in my self written Modelbinder.
Request.Form raises an error when the content is not a form.
#29 

With best regards,
Bjego